### PR TITLE
adding in ability to choose logic

### DIFF
--- a/floodwatch/src/js/components/Compare.js
+++ b/floodwatch/src/js/components/Compare.js
@@ -135,6 +135,8 @@ export class CompareContainer extends Component {
       curInfo.push({name: filtername, logic: logic, choices: []})
     }
 
+    console.log(filtername)
+
     if (side == 'left') {
       this.updateData(curInfo, this.state.rightOptions)
     } else if (side == 'right') {
@@ -163,10 +165,10 @@ export class CompareContainer extends Component {
         })
       }
 
-      if (f.name == "age") {
+      if (f.name == 'age') {
         if (f.choices[0]) {
-          const min = parseInt(f.choices[0].split("-")[0])
-          const max = parseInt(f.choices[0].split("-")[1])
+          const min = parseInt(f.choices[0].split('-')[0])
+          const max = parseInt(f.choices[0].split('-')[1])
           obj.age = {
             min: min,
             max: max
@@ -174,7 +176,7 @@ export class CompareContainer extends Component {
         }
       }
 
-      if (f.name == "country") {
+      if (f.name == 'country') {
         // tk
       }
     })

--- a/floodwatch/src/js/components/Compare.js
+++ b/floodwatch/src/js/components/Compare.js
@@ -92,7 +92,10 @@ export class CompareContainer extends Component {
     const filterA = this.generateFilterRequestItem(this.state.leftOptions)
     const filterB = this.generateFilterRequestItem(this.state.rightOptions)
 
-    const AdBreakdown = await FWApiClient.get().getFilteredAdCounts({ filterA: filterA, filterB: filterB })
+    const cleanedFilterA = this.cleanFilterRequest(filterA)
+    const cleanedFilterB = this.cleanFilterRequest(filterB)
+
+    const AdBreakdown = await FWApiClient.get().getFilteredAdCounts({ filterA: cleanedFilterA, filterB: cleanedFilterB })
     const FilterATopic = d3.entries(AdBreakdown.filterA.categories).sort(function(a, b) {
       return d3.descending(a.value, b.value);
     })[0]
@@ -113,9 +116,36 @@ export class CompareContainer extends Component {
     })
   }
 
+  updateSearchLogic(side: string, logic: string, filtername: string) {
+    let curInfo = []
+    if (side == 'left') {
+      curInfo = _.cloneDeep(this.state.leftOptions)
+    } else if (side == 'right') {
+      curInfo = _.cloneDeep(this.state.rightOptions)
+    }
+
+    let found = false;
+    for (let i = 0; i < curInfo.length; i++) {
+      if (curInfo[i].name == filtername)  {
+        curInfo[i].logic = logic
+        found = true;
+      }
+    }
+    if (found == false) {
+      curInfo.push({name: filtername, logic: logic, choices: []})
+    }
+
+    if (side == 'left') {
+      this.updateData(curInfo, this.state.rightOptions)
+    } else if (side == 'right') {
+      this.updateData(this.state.leftOptions, curInfo)
+    }
+  }
+
   generateFilterRequestItem(filter: Array<Filter>): FilterRequestItem {
     let obj = {
-      demographics: []
+      demographics: [],
+      age: {}
     };
     _.forEach(filter, (f: Filter) => {
       if (f.name != 'age' && f.name != 'country') {
@@ -132,8 +162,42 @@ export class CompareContainer extends Component {
           values: arr
         })
       }
+
+      if (f.name == "age") {
+        if (f.choices[0]) {
+          const min = parseInt(f.choices[0].split("-")[0])
+          const max = parseInt(f.choices[0].split("-")[1])
+          obj.age = {
+            min: min,
+            max: max
+          }
+        }
+      }
+
+      if (f.name == "country") {
+        // tk
+      }
     })
+
     return obj
+  }
+
+  cleanFilterRequest(filter: FilterRequestItem): FilterRequestItem {
+    if (!filter.demographics) {
+      return filter
+    }
+
+    if (filter.demographics.length == 0) {
+      return filter
+    }
+
+    for (let i = filter.demographics.length - 1; i >= 0; i--) {
+      if (filter.demographics[i].values.length == 0) {
+        filter.demographics.splice(i, 1)
+      }
+    }
+    return filter
+
   }
 
   changeCategoriesCustom(side: string, info: Filter, checked: boolean): void {
@@ -225,8 +289,11 @@ export class CompareContainer extends Component {
   async updateData(left: Array<Filter>, right: Array<Filter>) {
     const filterA = this.generateFilterRequestItem(left)
     const filterB = this.generateFilterRequestItem(right)
+   
+    const cleanedFilterA = this.cleanFilterRequest(filterA)
+    const cleanedFilterB = this.cleanFilterRequest(filterB)
 
-    const AdBreakdown = await FWApiClient.get().getFilteredAdCounts({ filterA: filterA, filterB: filterB })
+    const AdBreakdown = await FWApiClient.get().getFilteredAdCounts({ filterA: cleanedFilterA, filterB: cleanedFilterB })
 
     this.setState({
       leftData: (AdBreakdown.filterA.totalCount > 0) ? AdBreakdown.filterA.categories : {},
@@ -284,6 +351,7 @@ export class CompareContainer extends Component {
           currentSelectionRight={this.state.rightOptions}
           changeCategoriesPreset={this.changeCategoriesPreset.bind(this)}
           changeCategoriesCustom={this.changeCategoriesCustom.bind(this)}
+          updateSearchLogic={this.updateSearchLogic.bind(this)}
           userData={this.state.userData}/>
       </Row>
     )

--- a/floodwatch/src/js/components/ComparisonModal.js
+++ b/floodwatch/src/js/components/ComparisonModal.js
@@ -20,6 +20,7 @@ type PropsType = {
   toggleModal: () => void,
   changeCategoriesCustom: (side: string, obj: Filter, checked: boolean) => void,
   changeCategoriesPreset: (side: string, obj: Preset) => void,
+  updateSearchLogic: (logic: string, filtername: string, side: string) => void,
   userData: PersonResponse
 };
 
@@ -92,7 +93,8 @@ export class ComparisonModal extends Component {
             currentSentence={createSentence(this.props.currentSelectionLeft)}
             handlePresetClick={this.changeCategoriesPreset.bind(this)}
             handleCustomClick={this.handleCustomClick.bind(this, 'left')} 
-            handleFilterClick={this.props.changeCategoriesCustom.bind(this, 'left')}/>
+            handleFilterClick={this.props.changeCategoriesCustom.bind(this, 'left')}
+            updateSearchLogic={this.props.updateSearchLogic.bind(this, 'left')}/>
             </Col>
             <Col xs={2}>
           <div style={{textAlign:'center'}}>vs</div>
@@ -106,7 +108,8 @@ export class ComparisonModal extends Component {
             currentSentence={createSentence(this.props.currentSelectionRight)}
             handlePresetClick={this.changeCategoriesPreset.bind(this)}
             handleCustomClick={this.handleCustomClick.bind(this, 'right')} 
-            handleFilterClick={this.props.changeCategoriesCustom.bind(this, 'right')}/>
+            handleFilterClick={this.props.changeCategoriesCustom.bind(this, 'right')}
+            updateSearchLogic={this.props.updateSearchLogic.bind(this, 'right')}/>
             </Col>
           </Row>
         </Modal.Body>

--- a/floodwatch/src/js/components/CustomFilter.js
+++ b/floodwatch/src/js/components/CustomFilter.js
@@ -12,7 +12,8 @@ type PropType = {
   updateSearchLogic: (logic: string, filtername: string) => void,
   filter: FilterJSON,
   shouldBeDisabled: DisabledCheck,
-  mySelection: Filter
+  mySelection: Filter,
+  side: string
 };
 
 export class CustomFilter extends Component {
@@ -24,8 +25,7 @@ export class CustomFilter extends Component {
   }
 
   updateSearchLogic(event: any) {
-    console.log(event)
-    this.props.updateSearchLogic(event.target.value, event.target.name)
+    this.props.updateSearchLogic(event.target.value, event.target.name.split(this.props.side)[1])
   }
 
   render() {
@@ -33,7 +33,7 @@ export class CustomFilter extends Component {
       const obj = {
         'name': this.props.filter.name,
         'choices': [opt],
-        'logic': (this.props.mySelection) ? this.props.mySelection.logic : "or"
+        'logic': (this.props.mySelection) ? this.props.mySelection.logic : 'or'
       }
       
       let checked = false;
@@ -64,12 +64,13 @@ export class CustomFilter extends Component {
       }  
     }) 
 
-    const logicSelection = (this.props.mySelection) ? this.props.mySelection.logic : "or" 
+    const logicSelection = (this.props.mySelection) ? this.props.mySelection.logic : 'or' 
+    console.log(this.props.mySelection)
 
     let select = <FormGroup onChange={this.updateSearchLogic.bind(this)}>
-                    <Radio className="logic-option" checked={logicSelection == "or"} name={this.props.filter.name} inline value="or">Any of these</Radio>
-                    <Radio className="logic-option" checked={logicSelection == "and"} name={this.props.filter.name} inline value="and">All of these</Radio>
-                    <Radio className="logic-option" checked={logicSelection == "nor"} name={this.props.filter.name} inline value="nor">None of these</Radio>
+                    <Radio className="logic-option" checked={logicSelection == 'or'} name={this.props.side + this.props.filter.name} inline value="or">Any of these</Radio>
+                    <Radio className="logic-option" checked={logicSelection == 'and'} name={this.props.side + this.props.filter.name} inline value="and">All of these</Radio>
+                    <Radio className="logic-option" checked={logicSelection == 'nor'} name={this.props.side + this.props.filter.name} inline value="nor">None of these</Radio>
                   </FormGroup>
 
     return (

--- a/floodwatch/src/js/components/CustomFilter.js
+++ b/floodwatch/src/js/components/CustomFilter.js
@@ -2,39 +2,18 @@
 
 import React, {Component} from 'react';
 import $ from 'jquery';
-import { Button } from 'react-bootstrap';
+import { Button, FormGroup, Radio } from 'react-bootstrap';
 
 import type {FilterJSON, DisabledCheck, Filter} from './filtertypes.js'
 
 
 type PropType = {
   handleFilterClick: (obj: Filter, checked: boolean) => void,
+  updateSearchLogic: (logic: string, filtername: string) => void,
   filter: FilterJSON,
   shouldBeDisabled: DisabledCheck,
   mySelection: Filter
 };
-
-type StateType = {
-  opened: boolean,
-  curSettings: {
-    name: string,
-    options: any
-  },
-  logic: string
-};
-
-
-function CustomFilterInitialState(name: string): Object {
-  return {
-    opened: false,
-    curSettings: {
-      name: name,
-      options: null
-    },
-    logic: 'OR'
-  }
-}
-
 
 export class CustomFilter extends Component {
   props: PropType;
@@ -42,31 +21,19 @@ export class CustomFilter extends Component {
 
   constructor(props: PropType) {
     super(props);
-    this.state = CustomFilterInitialState(this.props.filter.name)
   }
 
-
-  // tk tk 
-  // toggleOpened() {
-  //   let newState = !this.state.opened;
-  //   this.setState({
-  //     opened: newState
-  //   })
-  // }
-
-  // updateSearchLogic(event) {
-  //   this.setState({
-  //     logic: event.target.value
-  //   })
-  // }
+  updateSearchLogic(event: any) {
+    console.log(event)
+    this.props.updateSearchLogic(event.target.value, event.target.name)
+  }
 
   render() {
-
     let elems = this.props.filter.options.map((opt: string, i: number) => {
       const obj = {
         'name': this.props.filter.name,
         'choices': [opt],
-        'logic': this.state.logic
+        'logic': (this.props.mySelection) ? this.props.mySelection.logic : "or"
       }
       
       let checked = false;
@@ -83,7 +50,7 @@ export class CustomFilter extends Component {
       if (disabled) {
         // tk
       } else {
-        return <div key={i} className="custom-option" /*style={{backgroundColor: backgroundColor}}*/>
+        return <div key={i} className="custom-option">
                     <Button href="#" active={checked}
                             disabled={disabled} 
                             onClick={this.props.handleFilterClick.bind(this, obj, !checked)} 
@@ -97,63 +64,19 @@ export class CustomFilter extends Component {
       }  
     }) 
 
-    // tk tk
-    // // first, check if this filter is enabled
-    // if (this.props.shouldBeDisabled[0].disabled) {
-    //   var myOverlay = <RequireOverlay requirements={this.props.shouldBeDisabled}/>
+    const logicSelection = (this.props.mySelection) ? this.props.mySelection.logic : "or" 
 
-    //   elems.push(
-    //     <OverlayTrigger rootClose={true} trigger="click" placement="right" overlay={myOverlay}>
-    //       <p className="unlock-description">Unlock by adding your info</p>
-    //     </OverlayTrigger>
-    //     )
-    // } else {
-    //   for (let i = 0; i < this.props.filter.options.length; i++) {
-    //     var obj = {
-    //       'name': this.props.filter.name,
-    //       'choices': this.props.filter.options[i],
-    //       'logic': this.state.logic
-    //     }
-
-    //     var checked = false;
-        
-    //     // see if we've selected anything already
-    //     if (this.props.mySelection) {
-    //       if ($.inArray(this.props.filter.options[i], this.props.mySelection.choices) > -1) {
-    //         checked = true;
-    //       }
-    //     }
-
-    //     let backgroundColor = 'transparent';
-    //     if (checked) {
-    //       backgroundColor = 'lightyellow'
-    //     }
-
-    //     elems.push(<div className="custom-option" style={{backgroundColor: backgroundColor}}><label><input checked={checked} onChange={this.props.handleFilterClick.bind(event, obj)} name={this.props.filter.name} type="checkbox"/>{this.props.filter.options[i]}</label></div>)
-    //   }
-    // }
-
-
-    
-
-    // let select = <select onChange={this.updateSearchLogic.bind(this)}>
-    //                 <option value="OR">checked ONE OR MORE of the following</option>
-    //                 <option value="AND">checked ONLY the following</option>
-    //                 <option value="NOT">have NOT CHECKED ANY OF the following</option>
-    //             </select>
-
-    // let display = 'none';
-    // if (this.state.opened) {
-    //   display = 'block'
-    // }
-
-    // let bgTest = (this.props.shouldBeDisabled[0].disabled == false) ? 'white' : '#efefef'
+    let select = <FormGroup onChange={this.updateSearchLogic.bind(this)}>
+                    <Radio className="logic-option" checked={logicSelection == "or"} name={this.props.filter.name} inline value="or">Any of these</Radio>
+                    <Radio className="logic-option" checked={logicSelection == "and"} name={this.props.filter.name} inline value="and">All of these</Radio>
+                    <Radio className="logic-option" checked={logicSelection == "nor"} name={this.props.filter.name} inline value="nor">None of these</Radio>
+                  </FormGroup>
 
     return (
-      <div className="filter-option" /*style={{backgroundColor:bgTest}}*/>
+      <div className="filter-option">
       <h4>Filter by {this.props.filter.name}</h4>
-      <div /*display={display}*/>
-      {/*<p>Show me people who have {select}:</p>*/}
+      <div>
+      <p>Show me people who chose {select}</p>
       {elems}
       </div>
       </div>

--- a/floodwatch/src/js/components/ModalSegment.js
+++ b/floodwatch/src/js/components/ModalSegment.js
@@ -13,6 +13,7 @@ type PropsType = {
   side: string,
   handleCustomClick: () => void,
   handleFilterClick: (obj: Filter, checked: boolean) => void,
+  updateSearchLogic: (logic: string, filtername: string) => void,
   currentSelection: Array<Filter>
 };
 
@@ -30,6 +31,7 @@ export class ModalSegment extends Component {
     } else {
       elem = <CustomOptions userData={this.props.userData} 
                             handleFilterClick={this.props.handleFilterClick} 
+                            updateSearchLogic={this.props.updateSearchLogic}
                             currentSelection={this.props.currentSelection}/>
     }
 

--- a/floodwatch/src/js/components/ModalSegment.js
+++ b/floodwatch/src/js/components/ModalSegment.js
@@ -29,7 +29,8 @@ export class ModalSegment extends Component {
     if (!this.props.isCustom) {
       elem = <RegularOptions currentSentence={this.props.currentSentence}/>
     } else {
-      elem = <CustomOptions userData={this.props.userData} 
+      elem = <CustomOptions side={this.props.side}
+                            userData={this.props.userData} 
                             handleFilterClick={this.props.handleFilterClick} 
                             updateSearchLogic={this.props.updateSearchLogic}
                             currentSelection={this.props.currentSelection}/>

--- a/floodwatch/src/js/components/Options.js
+++ b/floodwatch/src/js/components/Options.js
@@ -25,6 +25,7 @@ export class RegularOptions extends Component {
 type CustomOptionsProps = {
   currentSelection: Array<Filter>,
   handleFilterClick: (obj: Filter, checked: boolean) => void,
+  updateSearchLogic: (logic: string, filtername: string) => void,
   userData: PersonResponse
 };
 
@@ -47,6 +48,7 @@ export class CustomOptions extends Component {
       }
       return <CustomFilter key={i} 
                                 shouldBeDisabled={shouldBeDisabled} 
+                                updateSearchLogic={this.props.updateSearchLogic}
                                 handleFilterClick={this.props.handleFilterClick} 
                                 filter={item} 
                                 mySelection={thisCategorysSelection}/>

--- a/floodwatch/src/js/components/Options.js
+++ b/floodwatch/src/js/components/Options.js
@@ -26,7 +26,8 @@ type CustomOptionsProps = {
   currentSelection: Array<Filter>,
   handleFilterClick: (obj: Filter, checked: boolean) => void,
   updateSearchLogic: (logic: string, filtername: string) => void,
-  userData: PersonResponse
+  userData: PersonResponse,
+  side: string
 };
 
 
@@ -47,6 +48,7 @@ export class CustomOptions extends Component {
         thisCategorysSelection = this.props.currentSelection[index]
       }
       return <CustomFilter key={i} 
+                                side={this.props.side}
                                 shouldBeDisabled={shouldBeDisabled} 
                                 updateSearchLogic={this.props.updateSearchLogic}
                                 handleFilterClick={this.props.handleFilterClick} 

--- a/floodwatch/src/stubbed_data/filter_response.json
+++ b/floodwatch/src/stubbed_data/filter_response.json
@@ -6,7 +6,7 @@
                 {
                     "name":"data",
                     "choices": ["You"],
-                    "logic": "OR"
+                    "logic": "or"
                 }
             ],
             "always_available": true
@@ -22,7 +22,7 @@
                  {
                     "name": "gender",
                     "choices": ["Male"],
-                    "logic": "OR"
+                    "logic": "or"
                 }
             ]
         },
@@ -32,7 +32,7 @@
                  {
                     "name": "gender",
                     "choices": ["Female"],
-                    "logic": "OR"
+                    "logic": "or"
                 }
             ]
         },
@@ -42,12 +42,12 @@
                 {
                     "name": "race",
                     "choices": ["White"],
-                    "logic": "OR"
+                    "logic": "or"
                 },
                 {
                     "name": "religion",
                     "choices": ["Christian"],
-                    "logic": "OR"
+                    "logic": "or"
                 }
             ]
         },
@@ -57,12 +57,12 @@
                 {
                     "name": "gender",
                     "choices": ["Male"],
-                    "logic": "OR"
+                    "logic": "or"
                 },
                 {
                     "name": "age",
                     "choices": ["20-30"],
-                    "logic": "OR"
+                    "logic": "or"
                 }
             ]
         }


### PR DESCRIPTION
<img width="1010" alt="screen shot 2016-12-13 at 5 17 39 pm" src="https://cloud.githubusercontent.com/assets/1028403/21161815/374ed69c-c158-11e6-9208-a3f76273e26a.png">

Last big chunk of #21, hopefully.

This PR includes:
- The ability to choose different logic (and, or, nor) for your queries

This PR does not include:
- Updating the display sentence for and/or. (Right now, if it's nor, it'll say like 'non-white'--gotta figure out a way to phrase the others that's not awkward.)
- Locking age to just one value. (It should be, I keep procrastinating that because it's an irritating outlier.)
- Disabling the logic chooser for disabled categories. (In the meeting today, we discussed not having anything be disabled in the alpha anyway.)