### PR TITLE
Filter fixes

### DIFF
--- a/floodwatch/src/js/components/Compare.js
+++ b/floodwatch/src/js/components/Compare.js
@@ -135,8 +135,6 @@ export class CompareContainer extends Component {
       curInfo.push({name: filtername, logic: logic, choices: []})
     }
 
-    console.log(filtername)
-
     if (side == 'left') {
       this.updateData(curInfo, this.state.rightOptions)
     } else if (side == 'right') {
@@ -214,16 +212,20 @@ export class CompareContainer extends Component {
 
     for (let i = 0; i < curInfo.length; i++) {
       if (curInfo[i].name == info.name)  {
-        if (checked == true) {
-          curInfo[i].choices = _.union(curInfo[i].choices, info.choices)
-          curInfo[i].logic = info.logic
-          found = true;
-        } else {
-          _.remove(curInfo[i].choices, function(n: string) {
-            return n == info.choices[0]
-          })
-          found = true;
-        }
+          if (checked == true) {
+            if (info.name == "age") { // special case for age
+              curInfo[i].choices = info.choices // treat it like a radio button: only 1 choice allowed
+            } else {
+              curInfo[i].choices = _.union(curInfo[i].choices, info.choices)
+              curInfo[i].logic = info.logic
+            }
+            found = true;
+          } else {
+            _.remove(curInfo[i].choices, function(n: string) {
+              return n == info.choices[0]
+            })
+            found = true;
+          }
       }
     }
 

--- a/floodwatch/src/js/components/Compare.js
+++ b/floodwatch/src/js/components/Compare.js
@@ -212,20 +212,19 @@ export class CompareContainer extends Component {
 
     for (let i = 0; i < curInfo.length; i++) {
       if (curInfo[i].name == info.name)  {
-          if (checked == true) {
-            if (info.name == "age") { // special case for age
-              curInfo[i].choices = info.choices // treat it like a radio button: only 1 choice allowed
-            } else {
-              curInfo[i].choices = _.union(curInfo[i].choices, info.choices)
-              curInfo[i].logic = info.logic
-            }
-            found = true;
+        if (checked) {
+          if (info.name == 'age') { // special case for age
+            curInfo[i].choices = info.choices // treat it like a radio button: only 1 choice allowed
           } else {
-            _.remove(curInfo[i].choices, function(n: string) {
-              return n == info.choices[0]
-            })
-            found = true;
+            curInfo[i].choices = _.union(curInfo[i].choices, info.choices)
+            curInfo[i].logic = info.logic
           }
+        } else {
+          curInfo[i].choices = _.filter(curInfo[i].choices, function(n: string) {
+            return n != info.choices[0]
+          })
+        }
+        found = true;
       }
     }
 

--- a/floodwatch/src/js/components/CustomFilter.js
+++ b/floodwatch/src/js/components/CustomFilter.js
@@ -3,6 +3,7 @@
 import React, {Component} from 'react';
 import $ from 'jquery';
 import { Button, FormGroup, Radio } from 'react-bootstrap';
+import _ from "lodash"
 
 import type {FilterJSON, DisabledCheck, Filter} from './filtertypes.js'
 
@@ -29,7 +30,9 @@ export class CustomFilter extends Component {
   }
 
   render() {
-    let elems = this.props.filter.options.map((opt: string, i: number) => {
+    let elems = [];
+
+    _.forEach(this.props.filter.options, (opt: string, i: number) => {
       const obj = {
         'name': this.props.filter.name,
         'choices': [opt],
@@ -47,10 +50,8 @@ export class CustomFilter extends Component {
       if (this.props.shouldBeDisabled.disabled) {
         disabled = true
       }
-      if (disabled) {
-        // tk
-      } else {
-        return <div key={i} className="custom-option">
+      if (!disabled) {
+        elems.push(<div key={i} className="custom-option">
                     <Button href="#" active={checked}
                             disabled={disabled} 
                             onClick={this.props.handleFilterClick.bind(this, obj, !checked)} 
@@ -58,31 +59,50 @@ export class CustomFilter extends Component {
                     {opt}
                     </Button>
                   
-                </div>
-
-                  
-      }  
+                </div>)
+      }
+      return
     }) 
 
-    const logicSelection = (this.props.mySelection) ? this.props.mySelection.logic : 'or' 
-    console.log(this.props.mySelection)
+    let select = this.generateLogicSelectors();
 
-    let select = <FormGroup onChange={this.updateSearchLogic.bind(this)}>
-                    <Radio className="logic-option" checked={logicSelection == 'or'} name={this.props.side + this.props.filter.name} inline value="or">Any of these</Radio>
-                    <Radio className="logic-option" checked={logicSelection == 'and'} name={this.props.side + this.props.filter.name} inline value="and">All of these</Radio>
-                    <Radio className="logic-option" checked={logicSelection == 'nor'} name={this.props.side + this.props.filter.name} inline value="nor">None of these</Radio>
-                  </FormGroup>
+    if (elems.length == 0) {
+      elems.push(`Unlock by adding your ${this.props.filter.name} information to your profile.`)
+    } else {
+      elems.unshift(select)
+    }
 
     return (
       <div className="filter-option">
       <h4>Filter by {this.props.filter.name}</h4>
       <div>
-      <p>Show me people who chose {select}</p>
       {elems}
       </div>
       </div>
     )
 
+  }
+
+  generateLogicSelectors(): Element {
+    const logicSelection = (this.props.mySelection) ? this.props.mySelection.logic : 'or' 
+    
+    let or, and, nor;
+    or = <Radio className="logic-option" checked={logicSelection == 'or'} name={this.props.side + this.props.filter.name} inline value="or">Any of these</Radio>;
+    if (this.props.filter.name != "age") {
+      and = <Radio className="logic-option" checked={logicSelection == 'and'} name={this.props.side + this.props.filter.name} inline value="and">All of these</Radio>
+      nor = <Radio className="logic-option" checked={logicSelection == 'nor'} name={this.props.side + this.props.filter.name} inline value="nor">None of these</Radio>
+    }
+
+    let select = <div>
+                  <p>Show me people who chose</p>
+                  <FormGroup onChange={this.updateSearchLogic.bind(this)}>
+                    {or}
+                    {and}
+                    {nor}
+                  </FormGroup>
+                </div>
+
+    return select
   }
 
 }

--- a/floodwatch/src/js/components/CustomFilter.js
+++ b/floodwatch/src/js/components/CustomFilter.js
@@ -3,7 +3,7 @@
 import React, {Component} from 'react';
 import $ from 'jquery';
 import { Button, FormGroup, Radio } from 'react-bootstrap';
-import _ from "lodash"
+import _ from 'lodash'
 
 import type {FilterJSON, DisabledCheck, Filter} from './filtertypes.js'
 
@@ -87,10 +87,10 @@ export class CustomFilter extends Component {
     const logicSelection = (this.props.mySelection) ? this.props.mySelection.logic : 'or' 
     
     let or, and, nor;
-    or = <Radio className="logic-option" checked={logicSelection == 'or'} name={this.props.side + this.props.filter.name} inline value="or">Any of these</Radio>;
-    if (this.props.filter.name != "age") {
-      and = <Radio className="logic-option" checked={logicSelection == 'and'} name={this.props.side + this.props.filter.name} inline value="and">All of these</Radio>
-      nor = <Radio className="logic-option" checked={logicSelection == 'nor'} name={this.props.side + this.props.filter.name} inline value="nor">None of these</Radio>
+    or = <Radio className="logic-option" checked={logicSelection == 'or'} name={this.props.side + this.props.filter.name} inline readOnly value="or">Any of these</Radio>;
+    if (this.props.filter.name != 'age') {
+      and = <Radio className="logic-option" checked={logicSelection == 'and'} name={this.props.side + this.props.filter.name} inline readOnly value="and">All of these</Radio>
+      nor = <Radio className="logic-option" checked={logicSelection == 'nor'} name={this.props.side + this.props.filter.name} inline readOnly value="nor">None of these</Radio>
     }
 
     let select = <div>


### PR DESCRIPTION
<img width="1006" alt="screen shot 2016-12-13 at 6 08 33 pm" src="https://cloud.githubusercontent.com/assets/1028403/21163161/67a2dfd0-c15f-11e6-8d19-747b5a39b29c.png">

I thought these edge cases were going to take forever (see #48), but they took all of 10 minutes. Shrug emoji.

What this includes:
* Locking age to just one value.
* Disabling the logic chooser for disabled categories.

Any tweaks to the big conclusion sentence below should be on a dashboard related issue, not a filter one. 

In terms of the alpha--where we aren't having inline demographic inputs--this has all the required functionality for launch. Once this is closed, we have everything we need to close #21.