### PR TITLE
Hotfix for profile page

### DIFF
--- a/floodwatch/src/js/components/Profile.js
+++ b/floodwatch/src/js/components/Profile.js
@@ -100,17 +100,12 @@ export class DemographicContainer extends Component {
     }
   }
 
-  handleClick(checked: boolean, event: any): void {
-    let demo = event.target.textContent;
-    let demo_id = _.find(DemographicKeys.demographic_keys, (o: DemographicDictionary) => {
-      return o.name == demo
-    })
-
+  handleClick(checked: boolean, id: number, event: any): void {
     if (event.target.name != 'age' && event.target.name != 'country_code') {
       if (checked) {
-        this.addToDemographicIds(demo_id.id)
+        this.addToDemographicIds(id)
       } else {
-        this.removeFromDemographicIds(demo_id.id)
+        this.removeFromDemographicIds(id)
       }
     }
   }

--- a/floodwatch/src/js/components/ProfileOptions.js
+++ b/floodwatch/src/js/components/ProfileOptions.js
@@ -48,7 +48,7 @@ export class AgeOption extends Component {
 
   render() {
     let value = (this.props.userData) ? this.props.userData.birth_year : ''
-    let elem = <input onChange={this.props.updateYear} value={value} type="number"/>
+    let elem = <input min="0" onChange={this.props.updateYear} value={value} type="number"/>
     return (
       <Row className="demographic-category">
         <Col xs={12}>
@@ -212,23 +212,26 @@ export class DefaultOption extends Component {
 
   render() {
     let elems;
-    if (this.props.userData) {      
-      elems = this.props.filter.options.map((opt: string, key: number) => {
+    if (this.props.userData) {
+      let myOptions = _.filter(DemographicKeys.demographic_keys, (key) => {
+        return key.category_id == this.props.filter.category_id
+      })
+      elems = myOptions.map((opt: string, key: number) => {
         let val = _.find(DemographicKeys.demographic_keys, (o: DemographicDictionary) => {
-          return o.name == opt
+          return o.id == opt.id
         })
 
         let checked = false;
         if (val) {
           checked = (_.indexOf(this.props.userData.demographic_ids, val.id) > -1)
         }
-
+        
         return <div key={key} className="custom-option">
                     <Button
                     active={checked}
                     name={this.props.filter.name}
-                    onClick={this.props.handleClick.bind(this, !checked)}>
-                    {opt}
+                    onClick={this.props.handleClick.bind(this, !checked, opt.id)}>
+                    {opt.name}
                     </Button>
                 </div>
       })

--- a/floodwatch/src/stubbed_data/filter_response.json
+++ b/floodwatch/src/stubbed_data/filter_response.json
@@ -85,12 +85,12 @@
             ]
             
         },
-
         {
             "name": "gender",  
             "type": "checkbox",          
             "question": "What is your gender identity? Please choose all that apply.",
             "why": "A CMU study found that simulated male profiles received ads that were associated with $200,000 jobs six times more often than the simulated female profiles.",
+            "category_id": 3,
             "options": [
                 "Trans",
                 "Male",
@@ -106,6 +106,7 @@
             "type": "checkbox",
             "question": "What is your race/ethnicity? Please choose all that apply.",
             "why": "See Latanya Sweeney's analysis of racial discrimination in online advertising.",
+            "category_id": 2,
             "options": [
                 "American Indian or Alaska Native",
                 "Hispanic, Latino, or Spanish origin",
@@ -114,15 +115,15 @@
                 "Middle Eastern or North American",
                 "Black or African American",
                 "Native Hawaiian or Other Pacific Islander",
-                "Another race or ethnicity not listed here"
-            ]
-            
+                "Other"
+            ]  
         },
         {
             "name": "religion",
             "question": "What is your religion? Please choose all that apply.",
             "why": "In the USA, religion is a 'protected class', meaning that it is illegal to discriminate against someone on the basis of their faith.",
             "type": "checkbox",
+            "category_id": 1,
             "options": [
                 "Muslim",
                 "Hindu",
@@ -130,18 +131,17 @@
                 "Jewish",
                 "Buddhist",
                 "Agnostic",
-                "Atheist"
+                "Atheist",
+                "Other"
             ]
-            
         },
         {
             "name": "country", 
             "type": "dropdown",
             "aka": "country_code",
-            "question": "Where are you from?",
+            "question": "Where do you live?",
             "why": "In the USA, national origin is a 'protected class', meaning that it is illegal to discriminate against someone on the basis of where they're from.",
             "options": []
         }
-
     ]
 }


### PR DESCRIPTION
Fixing a bug with the profile page. 

We should change the comparison page so it acts more like the profile page does now, I think. The difference is that now, the profile page surfaces the options for each demographic question from the Demographic_Keys file, rather than the Filter_Response file. This, among other things, got us into 'two sources of truth' territory and it got ugly.

Right now you'll see both category_ids and options in the filter_response file. The next proper pull request will remove the latter--once I fix up the comparison page, I can just rely on demographic_keys for all that info.