### PR TITLE
making comparison page more resilient

### DIFF
--- a/floodwatch/src/js/components/Compare.js
+++ b/floodwatch/src/js/components/Compare.js
@@ -150,9 +150,12 @@ export class CompareContainer extends Component {
     _.forEach(filter, (f: Filter) => {
       if (f.name != 'age' && f.name != 'country') {
         let arr = []
-        _.forEach(f.choices, (choice) => {
+
+        const myCategoryId = DemographicKeys.category_to_id[f.name];
+
+        _.forEach(f.choices, (choice: string) => {
           for (let key of DemographicKeys.demographic_keys) {
-            if (key.name == choice) {
+            if (key.name == choice && key.category_id == myCategoryId) {
               arr.push(key.id)
             }
           }
@@ -224,11 +227,12 @@ export class CompareContainer extends Component {
             return n != info.choices[0]
           })
         }
+
         found = true;
       }
     }
 
-    if (found == false) {
+    if (!found && checked) {
       curInfo.push(info)
     }
 
@@ -236,8 +240,12 @@ export class CompareContainer extends Component {
     for (let [index: number, info: Filter] of curInfo.entries()) {
       if (info.name == 'data') {
         curInfo.splice(index, 1)
+      } else if (info.choices.length == 0) { // this feels like it should be handled by the above _.filter but it's not...
+        curInfo.splice(index, 1)
       }
     }
+
+    console.log(curInfo)
 
 
     if (side == 'left') {

--- a/floodwatch/src/js/components/Compare.js
+++ b/floodwatch/src/js/components/Compare.js
@@ -149,42 +149,16 @@ export class CompareContainer extends Component {
   }
 
   generateFilterRequestItem(filter: Array<Filter>): FilterRequestItem {
-    let isPersonal = false;
-    _.forEach(filter, (f) => {
-      if (f.name == 'data' && f.choices[0] == 'You') {
-        isPersonal = true;
-      }
-    })
-
+    const isPersonal = _.find(filter, f => f.name == 'data' && f.choices[0] == 'You');
     if (isPersonal) {
-      return {
-        personal: true
-      }
+      return { personal: true };
     }
 
-    let obj = {
-      demographics: [],
-      age: {}
+    const obj: FilterRequestItem = {
+      demographics: []
     };
-    _.forEach(filter, (f: Filter) => {
-      if (f.name != 'age' && f.name != 'country') {
-        let arr = []
 
-        const myCategoryId = DemographicKeys.category_to_id[f.name];
-
-        _.forEach(f.choices, (choice: string) => {
-          for (let key of DemographicKeys.demographic_keys) {
-            if (key.name == choice && key.category_id == myCategoryId) {
-              arr.push(key.id)
-            }
-          }
-        })
-        obj.demographics.push({
-          operator: f.logic,
-          values: arr
-        })
-      }
-
+    for (const f of filter) {
       if (f.name == 'age') {
         if (f.choices[0]) {
           const min = parseInt(f.choices[0].split('-')[0])
@@ -194,12 +168,23 @@ export class CompareContainer extends Component {
             max: max
           }
         }
+      } else if (f.name == 'country') {
+        // TK
+      } else {
+        const arr = [];
+        const myCategoryId = DemographicKeys.category_to_id[f.name];
+        for (const choice of f.choices) {
+          for (const key of DemographicKeys.demographic_keys) {
+            if (key.name == choice && key.category_id == myCategoryId) {
+              arr.push(key.id)
+            }
+          }
+        }
+        if (obj.demographics) {
+          obj.demographics.push({ operator: f.logic, values: arr });
+        }
       }
-
-      if (f.name == 'country') {
-        // tk
-      }
-    })
+    }
 
     return obj
   }

--- a/floodwatch/src/js/components/Compare.js
+++ b/floodwatch/src/js/components/Compare.js
@@ -71,8 +71,8 @@ type StateType = {
 
 function CompareContainerInitialState(): Object {
   return {
-    leftOptions: Filters.presets[1].filters,
-    rightOptions: Filters.presets[3].filters,
+    leftOptions: Filters.presets[0].filters,
+    rightOptions: Filters.presets[1].filters,
     leftData: {},
     rightData: {},
     currentTopic: '1',
@@ -143,6 +143,19 @@ export class CompareContainer extends Component {
   }
 
   generateFilterRequestItem(filter: Array<Filter>): FilterRequestItem {
+    let isPersonal = false;
+    _.forEach(filter, (f) => {
+      if (f.name == "data" && f.choices[0] == "You") {
+        isPersonal = true;
+      }
+    })
+
+    if (isPersonal) {
+      return {
+        personal: true
+      }
+    }
+
     let obj = {
       demographics: [],
       age: {}

--- a/floodwatch/src/js/components/Compare.js
+++ b/floodwatch/src/js/components/Compare.js
@@ -20,6 +20,9 @@ import TopicKeys from '../../stubbed_data/topic_keys.json';
 
 // import '../../Compare.css';
 
+const UNKNOWN = _.findKey(TopicKeys, (topic) => {
+  return (topic == 'Unknown')
+})
 
 export function createSentence(options: Array<Filter>): string {
   let sentence = 'Floodwatch users';
@@ -145,7 +148,7 @@ export class CompareContainer extends Component {
   generateFilterRequestItem(filter: Array<Filter>): FilterRequestItem {
     let isPersonal = false;
     _.forEach(filter, (f) => {
-      if (f.name == "data" && f.choices[0] == "You") {
+      if (f.name == 'data' && f.choices[0] == 'You') {
         isPersonal = true;
       }
     })
@@ -286,6 +289,10 @@ export class CompareContainer extends Component {
   generateDifferenceSentence(lVal: number, rVal: number): string {
     let sentence = '';
     const prc = Math.floor(this.calculatePercentDiff(lVal, rVal))
+
+    if (this.state.currentTopic == UNKNOWN) {
+      return sentence
+    }
 
     // Math.sign isn't supported on Chromium fwiw
     if (prc == -Infinity) {

--- a/floodwatch/src/js/components/ComparisonModal.js
+++ b/floodwatch/src/js/components/ComparisonModal.js
@@ -6,7 +6,7 @@ import {Modal, Button, Row, Col } from 'react-bootstrap'
 import {createSentence} from './Compare'
 import {ModalSegment} from './ModalSegment';
 
-import type {Filter, Preset} from './filtertypes'
+import type {Filter, Preset, FilterLogic} from './filtertypes'
 import type {PersonResponse} from '../api/types';
 
 import Filters from '../../stubbed_data/filter_response.json';
@@ -18,7 +18,7 @@ type PropsType = {
   toggleModal: () => void,
   changeCategoriesCustom: (side: string, obj: Filter, checked: boolean) => void,
   changeCategoriesPreset: (side: string, obj: Preset) => void,
-  updateSearchLogic: (logic: string, filtername: string, side: string) => void,
+  updateSearchLogic: (logic: string, filtername: FilterLogic, side: string) => void,
   userData: PersonResponse
 };
 
@@ -56,7 +56,7 @@ export class ComparisonModal extends Component {
     }
   }
 
-  changeCategoriesPreset(side: string, obj: Preset): void { 
+  changeCategoriesPreset(side: string, obj: Preset): void {
     if (side == 'right') {
       this.setState({
         rightIsCustom: false
@@ -83,14 +83,14 @@ export class ComparisonModal extends Component {
         <Modal.Body>
           <Row>
           <Col xs={5}>
-          <ModalSegment userData={this.props.userData} 
-            side="left" 
-            currentSelection={this.props.currentSelectionLeft} 
-            isCustom={this.state.leftIsCustom} 
+          <ModalSegment userData={this.props.userData}
+            side="left"
+            currentSelection={this.props.currentSelectionLeft}
+            isCustom={this.state.leftIsCustom}
             filterData={Filters}
             currentSentence={createSentence(this.props.currentSelectionLeft)}
             handlePresetClick={this.changeCategoriesPreset.bind(this)}
-            handleCustomClick={this.handleCustomClick.bind(this, 'left')} 
+            handleCustomClick={this.handleCustomClick.bind(this, 'left')}
             handleFilterClick={this.props.changeCategoriesCustom.bind(this, 'left')}
             updateSearchLogic={this.props.updateSearchLogic.bind(this, 'left')}/>
             </Col>
@@ -98,14 +98,14 @@ export class ComparisonModal extends Component {
           <div style={{textAlign:'center'}}>vs</div>
           </Col>
           <Col xs={5}>
-          <ModalSegment side="right" 
+          <ModalSegment side="right"
             userData={this.props.userData}
-            currentSelection={this.props.currentSelectionRight} 
-            isCustom={this.state.rightIsCustom} 
+            currentSelection={this.props.currentSelectionRight}
+            isCustom={this.state.rightIsCustom}
             filterData={Filters}
             currentSentence={createSentence(this.props.currentSelectionRight)}
             handlePresetClick={this.changeCategoriesPreset.bind(this)}
-            handleCustomClick={this.handleCustomClick.bind(this, 'right')} 
+            handleCustomClick={this.handleCustomClick.bind(this, 'right')}
             handleFilterClick={this.props.changeCategoriesCustom.bind(this, 'right')}
             updateSearchLogic={this.props.updateSearchLogic.bind(this, 'right')}/>
             </Col>

--- a/floodwatch/src/js/components/CustomFilter.js
+++ b/floodwatch/src/js/components/CustomFilter.js
@@ -7,12 +7,12 @@ import _ from 'lodash'
 
 import DemographicKeys from '../../stubbed_data/demographic_keys.json';
 
-import type {FilterJSON, DisabledCheck, Filter} from './filtertypes.js'
+import type {FilterJSON, DisabledCheck, Filter, FilterLogic} from './filtertypes.js'
 import type {DemographicDictionary} from './FindInDemographics'
 
 type PropType = {
   handleFilterClick: (obj: Filter, checked: boolean) => void,
-  updateSearchLogic: (logic: string, filtername: string) => void,
+  updateSearchLogic: (logic: FilterLogic, filtername: string) => void,
   filter: FilterJSON,
   shouldBeDisabled: DisabledCheck,
   mySelection: Filter,
@@ -61,12 +61,12 @@ export class CustomFilter extends Component {
       if (!disabled) {
         elems.push(<div key={i} className="custom-option">
                     <Button href="#" active={checked}
-                            disabled={disabled} 
-                            onClick={this.props.handleFilterClick.bind(this, obj, !checked)} 
+                            disabled={disabled}
+                            onClick={this.props.handleFilterClick.bind(this, obj, !checked)}
                             name={this.props.filter.name}>
                     {opt.name}
                     </Button>
-                  
+
                 </div>)
       }
     })
@@ -90,9 +90,9 @@ export class CustomFilter extends Component {
 
   }
 
-  generateLogicSelectors(): Element {
-    const logicSelection = (this.props.mySelection) ? this.props.mySelection.logic : 'or' 
-    
+  generateLogicSelectors(): React$Element<*> {
+    const logicSelection = (this.props.mySelection) ? this.props.mySelection.logic : 'or'
+
     let or, and, nor;
     or = <Radio className="logic-option" checked={logicSelection == 'or'} name={this.props.side + this.props.filter.name} inline readOnly value="or">Any of these</Radio>;
     if (this.props.filter.name != 'age') {

--- a/floodwatch/src/js/components/CustomFilter.js
+++ b/floodwatch/src/js/components/CustomFilter.js
@@ -5,8 +5,10 @@ import $ from 'jquery';
 import { Button, FormGroup, Radio } from 'react-bootstrap';
 import _ from 'lodash'
 
-import type {FilterJSON, DisabledCheck, Filter} from './filtertypes.js'
+import DemographicKeys from '../../stubbed_data/demographic_keys.json';
 
+import type {FilterJSON, DisabledCheck, Filter} from './filtertypes.js'
+import type {DemographicDictionary} from './FindInDemographics'
 
 type PropType = {
   handleFilterClick: (obj: Filter, checked: boolean) => void,
@@ -30,17 +32,24 @@ export class CustomFilter extends Component {
 
   render() {
     let elems = [];
+    let myOptions;
 
-    _.forEach(this.props.filter.options, (opt: string, i: number) => {
+    if (this.props.filter.category_id) {
+      myOptions = _.filter(DemographicKeys.demographic_keys, (opt: DemographicDictionary) => {
+        return opt.category_id == this.props.filter.category_id
+      })
+    }
+
+    _.forEach(myOptions, (opt: DemographicDictionary, i: number) => {
       const obj = {
         'name': this.props.filter.name,
-        'choices': [opt],
+        'choices': [opt.name],
         'logic': (this.props.mySelection) ? this.props.mySelection.logic : 'or'
       }
-      
+
       let checked = false;
       if (this.props.mySelection) {
-        if ($.inArray(opt, this.props.mySelection.choices) > -1) {
+        if ($.inArray(opt.name, this.props.mySelection.choices) > -1) {
           checked = true;
         }
       }
@@ -55,13 +64,12 @@ export class CustomFilter extends Component {
                             disabled={disabled} 
                             onClick={this.props.handleFilterClick.bind(this, obj, !checked)} 
                             name={this.props.filter.name}>
-                    {opt}
+                    {opt.name}
                     </Button>
                   
                 </div>)
       }
-      return
-    }) 
+    })
 
     let select = this.generateLogicSelectors();
 

--- a/floodwatch/src/js/components/FilterParent.js
+++ b/floodwatch/src/js/components/FilterParent.js
@@ -6,6 +6,11 @@ import $ from 'jquery';
 import {GraphParent} from './GraphParent';
 import _ from 'lodash';
 import d3 from 'd3'
+import TopicKeys from '../../stubbed_data/topic_keys.json';
+
+const UNKNOWN = _.findKey(TopicKeys, (topic) => {
+  return (topic == 'Unknown')
+})
 
 type StateType = {
   dataStackLayout: (data: Array<Array<StackedData>>) => Array<Array<StackedData>>
@@ -45,6 +50,9 @@ export class FilterParent extends Component {
 
   stackData(data: Object): Array<Array<StackedData>> {
     const topics = Object.keys(data);
+
+    console.log(data)
+
     let intermediate = topics.map((key: string): Array<StackedData> => {
       const dTemp = data[key]
       return [{x: 0, y: dTemp, name: key}]
@@ -53,6 +61,12 @@ export class FilterParent extends Component {
     intermediate.sort(function(a: Array<StackedData>, b: Array<StackedData>) {
       return d3.ascending(a[0].y, b[0].y);
     })
+
+    let unknown = _.remove(intermediate, (topic) => {
+      return topic[0].name == UNKNOWN
+    })
+
+    intermediate = _.concat(unknown, intermediate)
 
     const stack = this.state.dataStackLayout(intermediate)
     return stack;

--- a/floodwatch/src/js/components/Main.js
+++ b/floodwatch/src/js/components/Main.js
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 import {Link} from 'react-router';
 import {Grid, Nav, Navbar, NavItem, Row, Col} from 'react-bootstrap';
 
-import '../../css/App.css';
+import '../../css/app.css';
 
 import history from '../common/history';
 import {FWApiClient} from '../api/api';

--- a/floodwatch/src/js/components/Main.js
+++ b/floodwatch/src/js/components/Main.js
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 import {Link} from 'react-router';
 import {Grid, Nav, Navbar, NavItem, Row, Col} from 'react-bootstrap';
 
-import '../../css/app.css';
+import '../../css/App.css';
 
 import history from '../common/history';
 import {FWApiClient} from '../api/api';

--- a/floodwatch/src/js/components/ModalSegment.js
+++ b/floodwatch/src/js/components/ModalSegment.js
@@ -3,7 +3,7 @@
 import React, {Component} from 'react';
 import {RegularOptions, OptionDropdown, CustomOptions} from './Options'
 import type {PersonResponse} from '../api/types';
-import type {PresetsAndFilters, Filter, Preset} from './filtertypes';
+import type {PresetsAndFilters, Filter, Preset, FilterLogic} from './filtertypes';
 
 type PropsType = {
   filterData: PresetsAndFilters,
@@ -13,7 +13,7 @@ type PropsType = {
   side: string,
   handleCustomClick: () => void,
   handleFilterClick: (obj: Filter, checked: boolean) => void,
-  updateSearchLogic: (logic: string, filtername: string) => void,
+  updateSearchLogic: (logic: FilterLogic, filtername: string) => void,
   currentSelection: Array<Filter>
 };
 
@@ -30,19 +30,19 @@ export class ModalSegment extends Component {
       elem = <RegularOptions currentSentence={this.props.currentSentence}/>
     } else {
       elem = <CustomOptions side={this.props.side}
-                            userData={this.props.userData} 
-                            handleFilterClick={this.props.handleFilterClick} 
+                            userData={this.props.userData}
+                            handleFilterClick={this.props.handleFilterClick}
                             updateSearchLogic={this.props.updateSearchLogic}
                             currentSelection={this.props.currentSelection}/>
     }
 
     return (
       <div className="comparison-container">
-      <OptionDropdown userData={this.props.userData} 
-                      filterData={this.props.filterData} 
-                      currentSentence={this.props.currentSentence} 
-                      handlePresetClick={this.props.handlePresetClick.bind(this, this.props.side)} 
-                      side={this.props.side} 
+      <OptionDropdown userData={this.props.userData}
+                      filterData={this.props.filterData}
+                      currentSentence={this.props.currentSentence}
+                      handlePresetClick={this.props.handlePresetClick.bind(this, this.props.side)}
+                      side={this.props.side}
                       handleCustomClick={this.props.handleCustomClick}/>
       {elem}
       </div>

--- a/floodwatch/src/js/components/Options.js
+++ b/floodwatch/src/js/components/Options.js
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import {CustomFilter} from './CustomFilter'
 import {shouldPresetBeDisabled, shouldCustomBeDisabled} from './FindInDemographics'
 
-import type {Filter, Preset, PresetsAndFilters, FilterJSON} from './filtertypes.js'
+import type {Filter, FilterLogic, Preset, PresetsAndFilters, FilterJSON} from './filtertypes.js'
 import type {PersonResponse} from '../api/types';
 
 import Filters from '../../stubbed_data/filter_response.json';
@@ -25,7 +25,7 @@ export class RegularOptions extends Component {
 type CustomOptionsProps = {
   currentSelection: Array<Filter>,
   handleFilterClick: (obj: Filter, checked: boolean) => void,
-  updateSearchLogic: (logic: string, filtername: string) => void,
+  updateSearchLogic: (logic: FilterLogic, filtername: string) => void,
   userData: PersonResponse,
   side: string
 };
@@ -47,12 +47,12 @@ export class CustomOptions extends Component {
       if (index > -1) {
         thisCategorysSelection = this.props.currentSelection[index]
       }
-      return <CustomFilter key={i} 
+      return <CustomFilter key={i}
                                 side={this.props.side}
-                                shouldBeDisabled={shouldBeDisabled} 
+                                shouldBeDisabled={shouldBeDisabled}
                                 updateSearchLogic={this.props.updateSearchLogic}
-                                handleFilterClick={this.props.handleFilterClick} 
-                                filter={item} 
+                                handleFilterClick={this.props.handleFilterClick}
+                                filter={item}
                                 mySelection={thisCategorysSelection}/>
     })
 
@@ -83,17 +83,17 @@ export class OptionDropdown extends Component {
         // tk
         // var myOverlay = <RequireOverlay myKey={i} requirements={requirements.required}/>
       if (requirements.disabled == false) {
-        return  <MenuItem key={i} 
-                                disabled={requirements.disabled} 
+        return  <MenuItem key={i}
+                                disabled={requirements.disabled}
                                 onClick={this.props.handlePresetClick.bind(this, item, this.props.side)}>
                                 {item.name}
                 </MenuItem>
       } else {
-        return  <MenuItem key={i} 
+        return  <MenuItem key={i}
                       disabled={requirements.disabled}>
                       {item.name} (Requires info)
                 </MenuItem>
-        
+
       }
     })
     return (
@@ -102,7 +102,7 @@ export class OptionDropdown extends Component {
            <MenuItem header> Presets </MenuItem>
            {elems}
            <MenuItem header> Custom </MenuItem>
-           <MenuItem onClick={this.props.handleCustomClick}>Make your own filter</MenuItem> 
+           <MenuItem onClick={this.props.handleCustomClick}>Make your own filter</MenuItem>
          </DropdownButton>
        </ButtonToolbar>
     )

--- a/floodwatch/src/js/components/Profile.js
+++ b/floodwatch/src/js/components/Profile.js
@@ -85,17 +85,20 @@ export class DemographicContainer extends Component {
     this.state = setInitialStateDemographicContainer();
   }
 
-  async componentDidMount() {
-    try {
-      const UserData = await FWApiClient.get().getCurrentPerson()
-      let filteredUserData = _.pick(UserData, TO_PICK)
-      this.setState({
-        userData: filteredUserData,
-      })  
-    } catch (e) {
-      this.setState({curStatus: 'error'})
-      console.error(e)
-    }
+  componentDidMount() {
+    const init = async () => {
+      try {
+        const UserData = await FWApiClient.get().getCurrentPerson()
+        let filteredUserData = _.pick(UserData, TO_PICK)
+        this.setState({
+          userData: filteredUserData,
+        })
+      } catch (e) {
+        this.setState({curStatus: 'error'})
+        console.error(e)
+      }
+    };
+    init();
   }
 
   handleClick(checked: boolean, id: number, event: any): void {
@@ -110,12 +113,17 @@ export class DemographicContainer extends Component {
 
   async updateUserInfo() {
     try {
-      const reply = await FWApiClient.get().updatePersonDemographics(this.state.userData)  
-      let filteredUserData = _.pick(reply, TO_PICK)
-      this.setState({
-        userData: filteredUserData,
-        curStatus: 'success'
-      })  
+      if (this.state.userData) {
+        const userData = this.state.userData;
+        const reply = await FWApiClient.get().updatePersonDemographics(userData);
+        let filteredUserData = _.pick(reply, TO_PICK)
+        this.setState({
+          userData: filteredUserData,
+          curStatus: 'success'
+        })
+      } else {
+        this.setState({curStatus: 'error'});
+      }
     } catch (e) {
       console.error(e)
       this.setState({curStatus: 'error'})
@@ -159,13 +167,13 @@ export class DemographicContainer extends Component {
     let elems = Filters.filters.map((filter) => {
       if (filter.name == 'age') {
         return <AgeOption updateYear={this.updateYear.bind(this)}
-                          handleClick={this.handleClick.bind(this)} 
+                          handleClick={this.handleClick.bind(this)}
                           userData={this.state.userData} filter={filter}/>
 
       } else if (filter.name == 'country') {
         return <LocationOption
                           updateLocation={this.updateLocation.bind(this)}
-                          handleClick={this.handleClick.bind(this)} 
+                          handleClick={this.handleClick.bind(this)}
                           userData={this.state.userData} filter={filter}/>
       } else {
         return <DefaultOption
@@ -179,7 +187,7 @@ export class DemographicContainer extends Component {
     const displayGroup = (this.state.curStatus == null) ? 'none' : 'block'
 
     return (
-      <Row> 
+      <Row>
         <Col xs={12}>
         {elems}
         </Col>
@@ -189,12 +197,12 @@ export class DemographicContainer extends Component {
           { this.state.curStatus == 'success' &&
             <ListGroupItem bsStyle="success">
               Successfully saved changes!
-            </ListGroupItem> 
+            </ListGroupItem>
           }
           { this.state.curStatus == 'error' &&
             <ListGroupItem bsStyle="danger">
               Error while trying to save changes. Please check your connection.
-            </ListGroupItem> 
+            </ListGroupItem>
           }
         </ListGroup>
         </Col>

--- a/floodwatch/src/js/components/ProfileOptions.js
+++ b/floodwatch/src/js/components/ProfileOptions.js
@@ -214,7 +214,7 @@ export class DefaultOption extends Component {
       let myOptions = _.filter(DemographicKeys.demographic_keys, (key) => {
         return key.category_id == this.props.filter.category_id
       })
-      elems = myOptions.map((opt: string, key: number) => {
+      elems = myOptions.map((opt: DemographicDictionary, key: number) => {
         let val = _.find(DemographicKeys.demographic_keys, (o: DemographicDictionary) => {
           return o.id == opt.id
         })

--- a/floodwatch/src/js/components/filtertypes.js
+++ b/floodwatch/src/js/components/filtertypes.js
@@ -11,10 +11,12 @@ export type Preset = { // FilterOptionsType
   always_available?: boolean
 };
 
+export type FilterLogic = 'or' | 'nor' | 'and';
+
 export type Filter = { // FilterType
   name: string,
   choices: Array<string>,
-  logic: string
+  logic: FilterLogic
 };
 
 export type FilterJSON = {
@@ -22,8 +24,8 @@ export type FilterJSON = {
   options: Array<string>,
   question: string,
   type: string,
-  why: string
-
+  why: string,
+  category_id?: number
 };
 
 export type DisabledCheck = {

--- a/floodwatch/src/stubbed_data/filter_response.json
+++ b/floodwatch/src/stubbed_data/filter_response.json
@@ -90,58 +90,28 @@
             "type": "checkbox",          
             "question": "What is your gender identity? Please choose all that apply.",
             "why": "A CMU study found that simulated male profiles received ads that were associated with $200,000 jobs six times more often than the simulated female profiles.",
-            "category_id": 3,
-            "options": [
-                "Trans",
-                "Male",
-                "Female",
-                "Nonbinary",
-                "Agender",
-                "Other"
-            ]
-            
+            "category_id": 3
         },
         {
             "name": "race",
             "type": "checkbox",
             "question": "What is your race/ethnicity? Please choose all that apply.",
             "why": "See Latanya Sweeney's analysis of racial discrimination in online advertising.",
-            "category_id": 2,
-            "options": [
-                "American Indian or Alaska Native",
-                "Hispanic, Latino, or Spanish origin",
-                "White",
-                "Asia",
-                "Middle Eastern or North American",
-                "Black or African American",
-                "Native Hawaiian or Other Pacific Islander",
-                "Other"
-            ]  
+            "category_id": 2
         },
         {
             "name": "religion",
             "question": "What is your religion? Please choose all that apply.",
             "why": "In the USA, religion is a 'protected class', meaning that it is illegal to discriminate against someone on the basis of their faith.",
             "type": "checkbox",
-            "category_id": 1,
-            "options": [
-                "Muslim",
-                "Hindu",
-                "Christian",
-                "Jewish",
-                "Buddhist",
-                "Agnostic",
-                "Atheist",
-                "Other"
-            ]
+            "category_id": 1
         },
         {
             "name": "country", 
             "type": "dropdown",
             "aka": "country_code",
             "question": "Where do you live?",
-            "why": "In the USA, national origin is a 'protected class', meaning that it is illegal to discriminate against someone on the basis of where they're from.",
-            "options": []
+            "why": "In the USA, national origin is a 'protected class', meaning that it is illegal to discriminate against someone on the basis of where they're from."
         }
     ]
 }


### PR DESCRIPTION
In the transition from stubbed data to real data, we (I) accidentally got mired in Two Sources Of Truth Land, which is never a good thing. I'm hoping this PR will largely fix that.

To recap:
* For a while, I had been stubbing the data using [this file](https://github.com/O-C-R/floodwatch/blob/181b65bb984c86bb345de6a5b223292b873edab0/floodwatch/src/stubbed_data/filter_response.json).
* Then we got the demographics working, at which point I started using [this file](https://github.com/O-C-R/floodwatch/blob/develop/floodwatch/src/stubbed_data/demographic_keys.json) to actually encode the queries for the backend.
* But I was still pulling the actual values for the options from the first file. That meant that the filtering/profile options didn't always match the options in the lookup table, and it also meant that any time Other was triggered in one category, it would get triggered for all. Oops!

In this PR, you can see that I've since stripped the options out of `filter_response.json`, and now I'm pulling them from the `demographic_keys` file instead, which I think largely removes our two sources of truth problem. 

FWIW, I'm still using the former to grab the `question` and `why` properties, as well as the `presets` options. We may want to fully merge these two files at some point, just to make it clean, but I think that'll be pretty straightforward, as opposed to this, which required a bit of untangling.