### PR TITLE
Chart Labels

### DIFF
--- a/floodwatch/src/js/components/Compare.js
+++ b/floodwatch/src/js/components/Compare.js
@@ -338,6 +338,7 @@ export class CompareContainer extends Component {
                 data={this.state.leftData}
                 currentSelection={this.state.leftOptions}
                 currentTopic={this.state.currentTopic}
+                sentence={createSentence(this.state.leftOptions)}
                 updateMouseOver={this.updateMouseOver.bind(this)}/>
             </Col>
 
@@ -347,6 +348,7 @@ export class CompareContainer extends Component {
                 side="right"
                 data={this.state.rightData}
                 currentSelection={this.state.rightOptions}
+                sentence={createSentence(this.state.rightOptions)}
                 currentTopic={this.state.currentTopic}
                 updateMouseOver={this.updateMouseOver.bind(this)}/>
             </Col>

--- a/floodwatch/src/js/components/FilterParent.js
+++ b/floodwatch/src/js/components/FilterParent.js
@@ -26,7 +26,8 @@ type PropsType = {
   side: string,
   currentTopic: string,
   updateMouseOver: (topic: string) => void,
-  data: UnstackedData
+  data: UnstackedData,
+  sentence: string
 };
 
 export type StackedData = {
@@ -80,12 +81,33 @@ export class FilterParent extends Component {
   }
 
   render() {
+    let elem;
     const data = this.stackData(this.props.data)
+    if (this.props.side == 'left') {
+      elem =
+            <div> 
+            <Col xs={3}>
+              <h5>{this.props.sentence}</h5>
+            </Col>
+            <Col xs={9}>
+              <GraphParent data={data} side={this.props.side} currentTopic={this.props.currentTopic} updateMouseOver={this.props.updateMouseOver}/>
+            </Col>
+            </div>
+    } else {
+      elem = <div>
+            <Col xs={10}>
+              <GraphParent data={data} side={this.props.side} currentTopic={this.props.currentTopic} updateMouseOver={this.props.updateMouseOver}/>
+            </Col>
+            <Col xs={2}>
+            <h5>{this.props.sentence}</h5>
+            </Col>
+            </div>
+    }
+
+    
     return (
       <Row>
-        <Col xs={12}>
-          <GraphParent data={data} side={this.props.side} currentTopic={this.props.currentTopic} updateMouseOver={this.props.updateMouseOver}/>
-        </Col>
+        {elem}
       </Row>
     )
   }

--- a/floodwatch/src/js/components/FilterParent.js
+++ b/floodwatch/src/js/components/FilterParent.js
@@ -83,23 +83,27 @@ export class FilterParent extends Component {
   render() {
     let elem;
     const data = this.stackData(this.props.data)
+
+    const graph = <GraphParent data={data} side={this.props.side} currentTopic={this.props.currentTopic} updateMouseOver={this.props.updateMouseOver}/>
+    const sentence = <h5>{this.props.sentence}</h5>
+
     if (this.props.side == 'left') {
       elem =
             <div> 
             <Col xs={3}>
-              <h5>{this.props.sentence}</h5>
+              {sentence}
             </Col>
             <Col xs={9}>
-              <GraphParent data={data} side={this.props.side} currentTopic={this.props.currentTopic} updateMouseOver={this.props.updateMouseOver}/>
+              {graph}
             </Col>
             </div>
     } else {
       elem = <div>
             <Col xs={10}>
-              <GraphParent data={data} side={this.props.side} currentTopic={this.props.currentTopic} updateMouseOver={this.props.updateMouseOver}/>
+              {graph}
             </Col>
             <Col xs={2}>
-            <h5>{this.props.sentence}</h5>
+              {sentence}
             </Col>
             </div>
     }


### PR DESCRIPTION
<img width="840" alt="screen shot 2016-12-21 at 10 23 14 am" src="https://cloud.githubusercontent.com/assets/1028403/21394758/e6995a9a-c767-11e6-928f-f4a774df0dc1.png">

Took a sec to address #63 and add labels to the side of the charts. I feel like lines 90-109 can be done more cleanly/more DRY, but my WEF brain isn't giving me any solutions at the moment. In any case, the Bootstrappy grid should result in proper wrapping for basically all but the longest words.

