### PR TITLE
cleanup

### DIFF
--- a/floodwatch/src/js/App.js
+++ b/floodwatch/src/js/App.js
@@ -67,7 +67,7 @@ export class App extends Component {
           <Route path="/reset_password" component={ResetPassword} />
 
           <Route path="compare" component={Compare} onEnter={requireAuth} />
-          
+
           <Route path="profile" component={ProfilePage} onEnter={requireAuth} />
         </Route>
         <Route path="/generate" component={Generate}/>

--- a/floodwatch/src/js/components/Chart.js
+++ b/floodwatch/src/js/components/Chart.js
@@ -299,7 +299,6 @@ export class Chart extends Component {
 
   render() {
     const processedData = this.processData(this.props.data, this.props.visibilityMap);
-
     let error;
     if (processedData.length <= 1) {
       error = <Col xs={12} md={8} className="chart" style={{ padding: '2px' }}>

--- a/floodwatch/src/js/components/Compare.js
+++ b/floodwatch/src/js/components/Compare.js
@@ -19,8 +19,8 @@ import Filters from '../../stubbed_data/filter_response.json';
 import TopicKeys from '../../stubbed_data/topic_keys.json';
 
 export type VisibilityMap = {
-  [catId : string]: "show" | "hide" | "other"
-}
+  [catId: string]: "show" | "hide" | "other"
+};
 
 export type UnstackedData = {
   [key: string]: number
@@ -107,7 +107,7 @@ export class CompareContainer extends Component {
   }
 
   mouseEnterHandler(newTopic: string): void {
-    if (newTopic !== "Other" && this.state.updateCurrentTopic) {
+    if (newTopic !== 'Other' && this.state.updateCurrentTopic) {
       this.setState({
         currentTopic: newTopic
       })
@@ -118,22 +118,22 @@ export class CompareContainer extends Component {
     if (this.state.updateCurrentTopic) {
       this.setState({
         currentTopic: null
-      })  
+      })
     }
   }
 
   mouseClickHandler(newTopic: string): void {
-    if (newTopic !== "Other") {
+    if (newTopic !== 'Other') {
       if (this.state.updateCurrentTopic) {
         this.setState({
           currentTopic: newTopic,
           updateCurrentTopic: false
-        })  
+        })
       } else {
         this.setState({
           currentTopic: newTopic,
           updateCurrentTopic: false
-        })  
+        })
       }
     }
   }
@@ -175,8 +175,6 @@ export class CompareContainer extends Component {
       demographics: []
     };
 
-
-
     for (const f of filter) {
       if (f.name === 'age') {
         if (f.choices[0]) {
@@ -206,7 +204,6 @@ export class CompareContainer extends Component {
         }
       }
     }
-
     return obj
   }
 
@@ -310,20 +307,20 @@ export class CompareContainer extends Component {
 
   shareComparison(): void {
     let obj = {
-      filterA: this.state.leftOptions,
+      filterA: this.generateFilterRequestItem(this.state.leftOptions),
       dataA: this.state.leftData,
-      filterB: this.state.rightOptions,
+      filterB: this.generateFilterRequestItem(this.state.rightOptions),
       dataB: this.state.rightData,
       curTopic: this.state.currentTopic,
     }
 
-    let url = window.location.origin + "/generate?data=" + JSON.stringify(obj);
+    let url = window.location.origin + '/generate?data=' + JSON.stringify(obj);
 
     window.open(url);
   }
 
   clearTopic(event) {
-    if (event.target.tagName != "rect") {
+    if (event.target.tagName != 'rect') {
       this.setState({
         currentTopic: null,
         updateCurrentTopic: true

--- a/floodwatch/src/js/components/CustomFilter.js
+++ b/floodwatch/src/js/components/CustomFilter.js
@@ -46,7 +46,7 @@ export class CustomFilter extends Component {
     }
 
     let myOptions;
-    
+
 
     if (this.props.filter.name === 'country') {
       return (
@@ -73,7 +73,7 @@ export class CustomFilter extends Component {
         })
       }
     }
-  
+
     _.forEach(myOptions, (opt: DemographicDictionary, i: number) => {
 
       const obj = {
@@ -89,7 +89,7 @@ export class CustomFilter extends Component {
         }
       }
 
-      elems.push(<div key={i} className={"custom-option checkbox " + (checked ? "checked" : '')}>
+      elems.push(<div key={i} className={'custom-option checkbox ' + (checked ? 'checked' : '')}>
                   <Button href="#" active={checked}
                           disabled={this.props.shouldBeDisabled.disabled}
                           onClick={this.props.handleFilterClick.bind(this, obj, !checked)}
@@ -98,7 +98,7 @@ export class CustomFilter extends Component {
                   </Button>
 
               </div>)
-      
+
     })
 
     let select = this.generateLogicSelectors();
@@ -119,7 +119,7 @@ export class CustomFilter extends Component {
     const logicSelection = (this.props.mySelection) ? this.props.mySelection.logic : 'or'
 
     let or, and, nor;
-    
+
     if (this.props.filter.name !== 'age' && this.props.filter.name !== 'country') {
       or = <Radio className="logic-option" checked={logicSelection === 'or'} name={this.props.side + this.props.filter.name} inline readOnly value="or">Any of the following</Radio>;
       and = <Radio className="logic-option" checked={logicSelection === 'and'} name={this.props.side + this.props.filter.name} inline readOnly value="and">All of the following</Radio>
@@ -194,7 +194,7 @@ export class CountryFilter extends Component {
           inputProps={{name:'country', id: 'location-autocomplete', className: 'autocomplete_input form-control'}}
           value={this.state.value}
           items={this.state.items}
-          wrapperProps={{className:"autocomplete"}}
+          wrapperProps={{className:'autocomplete'}}
           getItemValue={(item) => item.feature.cc}
 
           onChange={(event, value) => {
@@ -213,7 +213,7 @@ export class CountryFilter extends Component {
           }}
 
           renderItem={(item, isHighlighted) => (
-            <div className={"autocomplete_options " + (isHighlighted && "current")}>
+            <div className={'autocomplete_options ' + (isHighlighted && 'current')}>
             {item.feature.displayName} ({item.feature.cc})
             </div>
           )}

--- a/floodwatch/src/js/components/FindInDemographics.js
+++ b/floodwatch/src/js/components/FindInDemographics.js
@@ -41,7 +41,7 @@ export function shouldPresetBeDisabled(userData: PersonResponse, preset: Preset)
         }
       }
     }
-   
+
     const filteredDemographics = _.filter(DemographicKeys.demographic_keys, function(dk) {
       return _.find(userData.demographic_ids, function(di: DemographicEntry) {
         if (dk.id === di) {
@@ -58,7 +58,7 @@ export function shouldPresetBeDisabled(userData: PersonResponse, preset: Preset)
     if (found) {
       thisFilter.disabled = false;
     }
-    
+
     return thisFilter
   })
 
@@ -82,7 +82,7 @@ export function shouldCustomBeDisabled(category: string, userData: PersonRespons
     return
   }
 
-  // age works a lil differently 
+  // age works a lil differently
   if (category === 'age') {
     if (userData.birth_year) {
       return {

--- a/floodwatch/src/js/components/Generate.js
+++ b/floodwatch/src/js/components/Generate.js
@@ -1,54 +1,95 @@
-import d3 from 'd3';
-// import _ from 'lodash';
+//@flow
+
+import type {Filter, FilterLogic} from './filtertypes'
+import type {PersonResponse, FilterRequestItem} from '../api/types';
+import type {VisibilityMap} from './Compare'
+
+import {getVisibilityMap, generateDifferenceSentence, createSentence} from './comparisontools';
+import DemographicKeys from '../../stubbed_data/demographic_keys.json';
 import React, { Component } from 'react';
 import { Row, Col } from 'react-bootstrap';
 import { Chart } from './Chart';
 import {render} from 'react-dom';
 import url from 'url';
+import _ from 'lodash';
 
-import {getVisibilityMap, generateDifferenceSentence, createSentence} from './comparisontools';
-import type {VisibilityMap} from './Compare'
 
+type StateType = {
+  filterA: any,
+  filterB: any,
+  dataA: any,
+  dataB: any,
+  curTopic: string,
+  visibilityMap: VisibilityMap,
+  lSentence: string,
+  rSentence: string,
+  sentence: string
+}
+
+function initialState(): StateType {
+  let curData = null;
+  if (url.parse(window.location.href, true).query.data) {
+    curData = JSON.parse(url.parse(window.location.href, true).query.data);
+  } else {
+    curData = {}
+  }
+
+  let visibilityMap = getVisibilityMap(curData.dataA, curData.dataB)
+  const lVal = curData.curTopic ? curData.dataA[curData.curTopic] : 0;
+  const rVal = curData.curTopic ? curData.dataB[curData.curTopic] : 0;
+
+  const lSentence = createSentence(decodeFilterRequestItem(curData.filterA));
+  const rSentence = createSentence(decodeFilterRequestItem(curData.filterB));
+
+  const sentence = generateDifferenceSentence(curData.filterA, curData.filterB, lVal, rVal, curData.curTopic)
+
+  return {
+    dataA: (curData.dataA) ? curData.dataA : {},
+    dataB: (curData.dataB) ? curData.dataB : {},
+    filterA: (curData.filterA) ? curData.filterA : {},
+    filterB: (curData.filterB) ? curData.filterB : {},
+    curTopic: (curData.curTopic) ? curData.curTopic : null,
+    visibilityMap: visibilityMap,
+    lSentence: lSentence,
+    rSentence: rSentence,
+    sentence: sentence
+  }
+}
 
 export class Generate extends Component {
+  state: StateType
+
+  constructor(props: PropsType) {
+    super(props);
+    this.state = initialState()
+  }
+
   render() {
-    let curData;
-    if (url.parse(window.location.href, true).query.data) {
-        curData = JSON.parse(url.parse(window.location.href, true).query.data);
-    }
-
-    let visibilityMap = getVisibilityMap(curData.dataA, curData.dataB)
-    const lVal = curData.curTopic ? curData.dataA[curData.curTopic] : 0;
-    const rVal = curData.curTopic ? curData.dataB[curData.curTopic] : 0;
-
-    const lSentence = createSentence(curData.filterA);
-    const rSentence = createSentence(curData.filterB);
-
-    const sentence = generateDifferenceSentence(curData.filterA, curData.filterB, lVal, rVal, curData.curTopic)
-
     return (
       <Row className="main generate">
         <Col xs={12}>
         <Row className="chart-container">
           <Col sm={5} smOffset={1} xs={10} xsOffset={1} style={{ padding:0 }}>
             <Chart
-              data={curData.dataA}
-              visibilityMap={visibilityMap}
-              currentTopic={curData.curTopic}
-              side={"left"}
-              sentence={lSentence}
+              data={this.state.dataA}
+              visibilityMap={this.state.visibilityMap}
+              currentTopic={this.state.curTopic}
+              side={'left'}
+              sentence={this.state.lSentence}
               mouseEnterHandler={()=>{}}
+              mouseClickHandler={()=>{}}
               mouseLeaveHandler={()=>{}}
               />
           </Col>
           <Col sm={5} smOffset={0} xs={10} xsOffset={1} style={{ padding:0 }}>
             <Chart
-              data={curData.dataB}
-              visibilityMap={visibilityMap}
-              currentTopic={curData.curTopic}
-              side={"right"}
-              sentence={rSentence}
+              data={this.state.dataB}
+              visibilityMap={this.state.visibilityMap}
+              currentTopic={this.state.curTopic}
+              side={'right'}
+              sentence={this.state.rSentence}
               mouseEnterHandler={()=>{}}
+              mouseClickHandler={()=>{}}
               mouseLeaveHandler={()=>{}}
               />
           </Col>
@@ -57,7 +98,7 @@ export class Generate extends Component {
           <Col xs={10} xsOffset={1} style={{ padding:0 }}>
             <Row>
               <Col md={8} mdOffset={2}>
-                <h3 className="chart-sentence">{sentence}</h3>
+                <h3 className="chart-sentence">{this.state.sentence}</h3>
               </Col>
             </Row>
           </Col>
@@ -66,4 +107,69 @@ export class Generate extends Component {
       </Row>
     )
   }
+}
+
+function decodeFilterRequestItem(filter: FilterRequestItem): Array<Filter> {
+  const keys = _.keys(filter)
+  const isPersonal = (_.indexOf(keys, 'personal') > -1);
+
+  if (isPersonal) {
+    return [{
+      name: 'data',
+      logic: 'or',
+      choices: ['You']
+    }]
+  }
+
+  let optionsArr = []
+
+  for (const k of keys) {
+    if (k == 'age') {
+      const str = filter[k].min + '-' + filter[k].max;
+      optionsArr.push({
+        name: 'age',
+        logic: 'or',
+        choices: [str]
+      })
+    } 
+    else if (k == 'location') {
+      let countries = filter[k].countryCodes;
+      optionsArr.push({
+        name: 'country',
+        logic: 'or',
+        choices: countries
+      })
+    } 
+    else if (k == 'demographics') {
+      if (filter[k].length > 0) {
+        filter[k].forEach((o) => {
+          let newObj = {};
+
+          newObj.logic = o.operator;
+          newObj.choices = [];
+          o.values.forEach((v) => {
+            let choice = _.find(DemographicKeys.demographic_keys, (dk) => {
+              return dk.id == v
+            })
+            newObj.choices.push(choice.name);
+          })
+
+          //get category of first elem to check what name of category is
+          let sampleElem = _.find(DemographicKeys.demographic_keys, (dk) => {
+            return dk.id == o.values[0]
+          })
+          let category = _.findKey(DemographicKeys.category_to_id, (ci) => {
+            return (ci == sampleElem.category_id)
+          })
+
+          newObj.name = 'category'
+
+          optionsArr.push(newObj)
+        })
+
+      }
+    }
+
+  }
+  return optionsArr
 }

--- a/floodwatch/src/js/components/Landing.js
+++ b/floodwatch/src/js/components/Landing.js
@@ -11,12 +11,12 @@ export class Landing extends Component {
 
   render() {
     const divStyle = {
-      backgroundImage: "url('static/img/home-back.png')",
+      backgroundImage: 'url(\'static/img/home-back.png\')',
     };
 
     return (
       <div className="home">
-        <div className="home_header" style={{backgroundImage: "url('static/img/home-back.png')"}}>
+        <div className="home_header" style={{backgroundImage: 'url(\'static/img/home-back.png\')'}}>
           <Row>
             <Col xs={10} xsOffset={1} md={8} mdOffset={2}>
               <div className="panel-container">

--- a/floodwatch/src/js/components/Main.js
+++ b/floodwatch/src/js/components/Main.js
@@ -79,7 +79,7 @@ export class Main extends Component {
 
   installClick() {
     chrome.webstore.install(
-      "https://chrome.google.com/webstore/detail/oiilbnnfccienlfahiecfglojnkhpgaf",
+      'https://chrome.google.com/webstore/detail/oiilbnnfccienlfahiecfglojnkhpgaf',
       () => { this.setState({ extensionInstalled: true }) },
       (err) => { console.error(err); }
     );
@@ -124,7 +124,7 @@ export class Main extends Component {
             loginChanged: this.loadUserFromServer.bind(this),
             handleLogout: this.handleLogout.bind(this),
             user: this.state.user
-           })}
+          })}
          </Row>
       </Grid>
     );

--- a/floodwatch/src/js/components/Navigation.js
+++ b/floodwatch/src/js/components/Navigation.js
@@ -8,7 +8,7 @@ import history from '../common/history';
 import {FWApiClient} from '../api/api';
 
 type NavigationProps = {
-  navs: Array<{ to?: string; name: string, action?: Function }>;
+  navs: Array<{ to?: string, name: string, action?: Function }>
 };
 
 type NavigationState = {

--- a/floodwatch/src/js/components/Profile.js
+++ b/floodwatch/src/js/components/Profile.js
@@ -72,7 +72,7 @@ function setInitialStateProfile() {
 }
 
 type DemographicContainerProps = {
-  onSuccess?: Function;
+  onSuccess?: Function
 };
 
 type DemographicContainerState = {
@@ -148,12 +148,12 @@ export class DemographicContainer extends Component {
           this.props.onSuccess();
         }
 
-        this.statusHandler("success", "Successfully saved changes!")
+        this.statusHandler('success', 'Successfully saved changes!')
       } else {
-        this.statusHandler("error", "Profile not loaded, please reload this page.");
+        this.statusHandler('error', 'Profile not loaded, please reload this page.');
       }
     } catch (e) {
-      this.statusHandler("error", "Error while trying to save changes. Please check your connection.");
+      this.statusHandler('error', 'Error while trying to save changes. Please check your connection.');
     }
   }
 

--- a/floodwatch/src/js/components/ProfileOptions.js
+++ b/floodwatch/src/js/components/ProfileOptions.js
@@ -51,7 +51,7 @@ export class AgeOption extends Component {
       <div className="profile-page_option panel-body">
         <div className="profile-page_option_header">
           <h4>{this.props.filter.question} <a onClick={this.toggleDescriptionVisibility.bind(this)}
-            className={"profile-page_learnmore " + (this.state.isDescriptionOpen ? "open" : '')}>
+            className={'profile-page_learnmore ' + (this.state.isDescriptionOpen ? 'open' : '')}>
               <span className="glyphicon glyphicon-info-sign"></span></a>
           </h4>
           { this.props.filter.instruction &&
@@ -154,7 +154,7 @@ export class LocationOption extends Component {
       <div className="profile-page_option panel-body">
         <div className="profile-page_option_header">
           <h4>{this.props.filter.question} <a onClick={this.toggleDescriptionVisibility.bind(this)}
-            className={"profile-page_learnmore " + (this.state.isDescriptionOpen ? "open" : '')}><
+            className={'profile-page_learnmore ' + (this.state.isDescriptionOpen ? 'open' : '')}><
             span className="glyphicon glyphicon-info-sign"></span></a>
           </h4>
           { this.props.filter.instruction &&
@@ -169,7 +169,7 @@ export class LocationOption extends Component {
           inputProps={{name:'country', id: 'location-autocomplete', className: 'autocomplete_input form-control'}}
           value={this.state.value}
           items={this.state.items}
-          wrapperProps={{className:"autocomplete"}}
+          wrapperProps={{className:'autocomplete'}}
           getItemValue={(item) => item.feature.displayName}
 
           onChange={(event, value) => {
@@ -183,7 +183,7 @@ export class LocationOption extends Component {
           }}
 
           renderItem={(item, isHighlighted) => (
-            <div className={"autocomplete_options " + (isHighlighted && "current")}>
+            <div className={'autocomplete_options ' + (isHighlighted && 'current')}>
             {item.feature.displayName}
             </div>
           )}
@@ -237,7 +237,7 @@ export class DefaultOption extends Component {
         }
 
         return (
-            <div key={key} className={"custom-option checkbox " + (checked ? "checked" : '')}>
+            <div key={key} className={'custom-option checkbox ' + (checked ? 'checked' : '')}>
               <label>
                 <input
                 type="checkbox"
@@ -255,7 +255,7 @@ export class DefaultOption extends Component {
       <div className="profile-page_option panel-body">
         <div className="profile-page_option_header">
           <h4>{this.props.filter.question} <a onClick={this.toggleDescriptionVisibility.bind(this)}
-            className={"profile-page_learnmore " + (this.state.isDescriptionOpen ? "open" : '')}>
+            className={'profile-page_learnmore ' + (this.state.isDescriptionOpen ? 'open' : '')}>
             <span className="glyphicon glyphicon-info-sign"></span></a>
           </h4>
           { this.props.filter.instruction &&

--- a/floodwatch/src/js/components/RegisterDemographics.js
+++ b/floodwatch/src/js/components/RegisterDemographics.js
@@ -8,7 +8,7 @@ import history from '../common/history';
 import {ProfileExplanation, DemographicContainer} from './Profile';
 
 type State = {
-  saving: boolean;
+  saving: boolean
 };
 
 function initialState(): State {

--- a/floodwatch/src/js/components/colors.js
+++ b/floodwatch/src/js/components/colors.js
@@ -21,5 +21,5 @@ module.exports = {
   'Automotive' : ['#c80018', '#f12b42'],
   'Apparel' : ['#ffae00', '#ffc618'],
   'Development / Design / Web-Services' : ['#ff5a00', '#fd730e'],
-  "Other": ["#89a4af", "#9cb5bf"]
+  'Other': ['#89a4af', '#9cb5bf']
 }

--- a/floodwatch/src/js/components/comparisontools.js
+++ b/floodwatch/src/js/components/comparisontools.js
@@ -1,14 +1,14 @@
 //@flow
 
-const unknownId = '16'
-const otherBreakDown = 0.02
+const UNKNOWN_ID = '16'
+const OTHER_BREAKDOWN = 0.02
 
 import TopicKeys from '../../stubbed_data/topic_keys.json';
 import _ from 'lodash';
 import type {Preset, Filter, FilterLogic} from './filtertypes'
-import type {VisibilityMap} from './Compare'
+import type {VisibilityMap, UnstackedData} from './Compare'
 
-export function getVisibilityMap(lD, rD): VisibilityMap {
+export function getVisibilityMap(lD: UnstackedData, rD: UnstackedData): VisibilityMap {
   let visibilityMap = {}
 
   let comparisonData = {}
@@ -19,8 +19,8 @@ export function getVisibilityMap(lD, rD): VisibilityMap {
   }
 
   for (let key in comparisonData) {
-    if (key !== unknownId) { // Hide cats (16 is unknown)
-      if ((comparisonData[key] > otherBreakDown) || (comparisonData[key] > otherBreakDown)) { // Make sure cats are above some percentage for both side
+    if (key !== UNKNOWN_ID) { // Hide cats (16 is unknown)
+      if ((comparisonData[key] > OTHER_BREAKDOWN) || (comparisonData[key] > OTHER_BREAKDOWN)) { // Make sure cats are above some percentage for both side
         visibilityMap[key] = 'show'
       } else {
         visibilityMap[key] = 'other'
@@ -32,7 +32,7 @@ export function getVisibilityMap(lD, rD): VisibilityMap {
   return visibilityMap;
 }
 
-export function generateDifferenceSentence(lO: Array<Filter>, rO: Array<Filter>, lVal: number, rVal: number, currentTopic: string): string {
+export function generateDifferenceSentence(lO: Array<Filter>, rO: Array<Filter>, lVal: number, rVal: number, currentTopic: ?string): string {
   let sentence = '';
   const prc = Math.floor(calculatePercentDiff(lVal, rVal))
 
@@ -54,6 +54,8 @@ export function generateDifferenceSentence(lO: Array<Filter>, rO: Array<Filter>,
 
 export function createSentence(options: Array<Filter>): string {
   let sentence = 'Floodwatch users';
+
+  console.log(options)
   if (options[0] == undefined) {
     sentence = 'All ' + sentence;
     return sentence;

--- a/floodwatch/src/js/components/comparisontools.js
+++ b/floodwatch/src/js/components/comparisontools.js
@@ -1,6 +1,6 @@
 //@flow
 
-const unknownId = "16"
+const unknownId = '16'
 const otherBreakDown = 0.02
 
 import TopicKeys from '../../stubbed_data/topic_keys.json';
@@ -9,45 +9,52 @@ import type {Preset, Filter, FilterLogic} from './filtertypes'
 import type {VisibilityMap} from './Compare'
 
 export function getVisibilityMap(lD, rD): VisibilityMap {
-    let visibilityMap = {}
+  let visibilityMap = {}
 
-    for (let key in lD) {
-      if (key !== unknownId) { // Hide cats (16 is unknown)
-        if ((lD[key] > otherBreakDown) || (lD[key] > otherBreakDown)) { // Make sure cats are above some percentage for both side
-          visibilityMap[key] = "show"
-        } else {
-          visibilityMap[key] = "other"
-        }
+  let comparisonData = {}
+  if (_.isEmpty(lD) && !_.isEmpty(rD)) {
+    console.log('hi')
+    comparisonData = _.cloneDeep(rD)
+  } else if (!_.isEmpty(lD)) {
+    comparisonData = _.cloneDeep(lD)
+  }
+
+  for (let key in comparisonData) {
+    if (key !== unknownId) { // Hide cats (16 is unknown)
+      if ((comparisonData[key] > otherBreakDown) || (comparisonData[key] > otherBreakDown)) { // Make sure cats are above some percentage for both side
+        visibilityMap[key] = 'show'
       } else {
-        visibilityMap[key] = "hide"
+        visibilityMap[key] = 'other'
       }
+    } else {
+      visibilityMap[key] = 'hide'
     }
-    return visibilityMap;
+  }
+  return visibilityMap;
 }
 
 export function generateDifferenceSentence(lO: Array<Filter>, rO: Array<Filter>, lVal: number, rVal: number, currentTopic: string): string {
-    let sentence = '';
-    const prc = Math.floor(calculatePercentDiff(lVal, rVal))
+  let sentence = '';
+  const prc = Math.floor(calculatePercentDiff(lVal, rVal))
 
     // Math.sign isn't supported on Chromium fwiw
-    if (prc === -Infinity) {
-      sentence = `On average, ${createSentence(lO)} don't see any ${TopicKeys[currentTopic]} ads, as opposed to ${createSentence(rO)}.`
-    } else if (prc === 100) {
-      sentence = `On average, ${createSentence(rO)} don't see any ${TopicKeys[currentTopic]} ads, as opposed to ${createSentence(lO)}.`
-    } else if (prc < 0) {
-      sentence = `On average, ${createSentence(lO)} see ${Math.abs(prc)}% less ${TopicKeys[currentTopic]} ads than ${createSentence(rO)}.`;
-    } else if (prc > 0) {
-      sentence = `On average, ${createSentence(lO)} see ${prc}% more ${TopicKeys[currentTopic]} ads than ${createSentence(rO)}.`;
-    } else if (prc === 0) {
-      sentence = `${createSentence(lO)} and ${createSentence(rO)} see the same amount of ${TopicKeys[currentTopic]} ads.`;
-    }
+  if (prc === -Infinity) {
+    sentence = `On average, ${createSentence(lO)} don't see any ${TopicKeys[currentTopic]} ads, as opposed to ${createSentence(rO)}.`
+  } else if (prc === 100) {
+    sentence = `On average, ${createSentence(rO)} don't see any ${TopicKeys[currentTopic]} ads, as opposed to ${createSentence(lO)}.`
+  } else if (prc < 0) {
+    sentence = `On average, ${createSentence(lO)} see ${Math.abs(prc)}% less ${TopicKeys[currentTopic]} ads than ${createSentence(rO)}.`;
+  } else if (prc > 0) {
+    sentence = `On average, ${createSentence(lO)} see ${prc}% more ${TopicKeys[currentTopic]} ads than ${createSentence(rO)}.`;
+  } else if (prc === 0) {
+    sentence = `${createSentence(lO)} and ${createSentence(rO)} see the same amount of ${TopicKeys[currentTopic]} ads.`;
+  }
 
-    return sentence;
+  return sentence;
 }
 
 export function createSentence(options: Array<Filter>): string {
-  let sentence = 'Floodwatch users'; 
-  
+  let sentence = 'Floodwatch users';
   if (options[0] == undefined) {
     sentence = 'All ' + sentence;
     return sentence;
@@ -83,7 +90,7 @@ export function createSentence(options: Array<Filter>): string {
       choices = wrappedChoices.join(' ' + opt.logic + ' ')
     }
 
-    sentence = sentence + ((index > 0) ? ", and " : " ") + choices;
+    sentence = sentence + ((index > 0) ? ', and ' : ' ') + choices;
   })
 
   return sentence

--- a/floodwatch/src/js/components/comparisontools.js
+++ b/floodwatch/src/js/components/comparisontools.js
@@ -13,7 +13,6 @@ export function getVisibilityMap(lD, rD): VisibilityMap {
 
   let comparisonData = {}
   if (_.isEmpty(lD) && !_.isEmpty(rD)) {
-    console.log('hi')
     comparisonData = _.cloneDeep(rD)
   } else if (!_.isEmpty(lD)) {
     comparisonData = _.cloneDeep(lD)

--- a/floodwatch/src/js/components/comparisontools.js
+++ b/floodwatch/src/js/components/comparisontools.js
@@ -55,7 +55,6 @@ export function generateDifferenceSentence(lO: Array<Filter>, rO: Array<Filter>,
 export function createSentence(options: Array<Filter>): string {
   let sentence = 'Floodwatch users';
 
-  console.log(options)
   if (options[0] == undefined) {
     sentence = 'All ' + sentence;
     return sentence;

--- a/floodwatch/src/js/components/filtertypes.js
+++ b/floodwatch/src/js/components/filtertypes.js
@@ -23,7 +23,7 @@ export type DemographicEntry = {
   name: string,
   category_id: number,
   id: number
-}
+};
 
 export type FilterJSON = {
   name: string,


### PR DESCRIPTION
This PR looks huge, but 50% of the changes are just random linter things in files that haven't otherwise been touched for a while. Basically everything that matters is, again, in Generate.js.

Mostly what this PR does is change what format the Generate page is expecting for the filter data. 
- Before, the format was like this:
```
"filterA": [
    {
      "name": "gender",
      "choices": [
        "Female"
      ],
      "logic": "or"
    }
  ],
```
- Now, the format is like this:
```
"filterA":{
     "demographics":[
          {"operator":"or","values":[17]}
     ]
}
```

This mirrors what we're sending the server when we ask for two demographics to compare. Here, that format is decoded in the `decodeFilterRequestItem` function, after which it's sent to the usual sentence generator.

There are also some small bugfixes, and some attempts to better adhere to what Flow is expecting.